### PR TITLE
fix: `infra.ci.jenkins.io` build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ COPY .sequelizerc ${APP_DIR}/
 
 EXPOSE 3030
 
-# hadoline ignore=DL3025
+# hadolint ignore=DL3025
 CMD node ./node_modules/.bin/sequelize db:migrate || node ./build/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent { 
-        // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
-        label 'docker || linux-amd64-docker'
+        // 'linux' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
+        label 'linux || linux-amd64-docker'
     }
 
     options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,6 +19,11 @@ pipeline {
             steps {
                 sh 'make migrate check'
             }
+            post {
+                success {
+                    stash name: 'build', includes: 'build'
+                }
+            }
         }
 
         stage('Containers') {
@@ -31,7 +36,7 @@ pipeline {
         stage('Publish container') {
             when { expression { infra.isInfra() } }
             steps {
-                buildDockerAndPublishImage('uplink')
+                buildDockerAndPublishImage('uplink', [unstash: 'build'])
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             }
             post {
                 success {
-                    stash name: 'build', includes: 'build'
+                    stash name: 'build', includes: 'build/**/*',
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         }
 
         stage('Containers') {
-            when { expression { not { infra.isInfra() } } }
+            when { expression { !infra.isInfra() } }
             steps {
                 sh 'make container'
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             }
             post {
                 success {
-                    stash name: 'build', includes: 'build/**/*',
+                    stash name: 'build', includes: 'build/**/*'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,8 @@
 pipeline {
-    agent { label 'linux' }
+    agent { 
+        // 'docker' is the (legacy) label used on ci.jenkins.io for "Docker Linux AMD64" while 'linux-amd64-docker' is the label used on infra.ci.jenkins.io
+        label 'docker || linux-amd64-docker'
+    }
 
     options {
         timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
Fixup of #42 

- set agent label for both ci.jenkins.io & infra.ci.jenkins.io
- fix `when` negation
- typo "hadoline"
- stash/unstash `build` artefact from nodejs