### PR TITLE
chore: add `release-drafter`

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,5 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
+_extends: .github
+
+name-template: 'next'
+tag-template: 'next'


### PR DESCRIPTION
Repo added to the GitHub App:

<img width="587" alt="image" src="https://github.com/jenkins-infra/uplink/assets/91831478/f5ffbe2f-2519-4772-b6b5-f140b3087571">
