### PR TITLE
chore: add `npm version` in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ publish: ## Publish the Docker container to docker hub
 	docker push ${IMAGE_NAME}:$(IMAGE_TAG)
 	docker push $(IMAGE_NAME):latest
 
-show-version:
-  npm version
+version:
+	npm version
 
-depends: show-version package.json package-lock.json ## Install node dependencies
+depends: version package.json package-lock.json ## Install node dependencies
 	if [ ! -d node_modules ]; then npm install; fi;
 
 build: depends ## Compile TypeScript

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ publish: ## Publish the Docker container to docker hub
 	docker push ${IMAGE_NAME}:$(IMAGE_TAG)
 	docker push $(IMAGE_NAME):latest
 
-depends: package.json package-lock.json ## Install node dependencies
+show-version:
+  npm version
+
+depends: show-version package.json package-lock.json ## Install node dependencies
 	if [ ! -d node_modules ]; then npm install; fi;
 
 build: depends ## Compile TypeScript


### PR DESCRIPTION
This PR adds `version` running `npm version` to be able to see every npm & nodejs related versions when building the app with `make`.

Additional output:
```
{ uplink: '1.0.0',
   npm: '6.14.12',
   ares: '1.15.0',
   brotli: '1.0.7',
   cldr: '35.1',
   http_parser: '2.9.4',
   icu: '64.2',
   modules: '64',
   napi: '7',
   nghttp2: '1.41.0',
   node: '10.24.1',
   openssl: '1.1.1k',
   tz: '2019c',
   unicode: '12.1',
   uv: '1.34.2',
   v8: '6.8.275.32-node.59',
   zlib: '1.2.11' }
```