### PR TITLE
Revert "fix: upgrade `pg` dependency from `^7.4.3` to `^8.7.1`"

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "helmet": "^3.13.0",
     "jsonstream": "^1.0.3",
     "passport-github": "^1.1.0",
-    "pg": "^8.7.1",
+    "pg": "^7.4.3",
     "pg-query-stream": "^1.1.2",
     "pug": "^2.0.4",
     "sequelize": "^4.38.0",


### PR DESCRIPTION
Reverts jenkins-infra/uplink#41 as doing so prevent correctly building the app deterministicly as there is now a mismatch between package.json and package-lock.json when running `npm ci` to fix #50 