### PR TITLE
fix: replace `npm install` by `npm ci` to get deterministic builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:9 as builder
 
+RUN npm install --global npm@5.7.0 && \
+    npm version
+
 ARG APP_DIR=/srv/uplink
 WORKDIR ${APP_DIR}
 
 COPY package*json ${APP_DIR}/
 
-RUN npm install
+RUN npm ci
 
 # Doing a multi-stage build to reset some stuff for a smaller image
 FROM node:9-alpine

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,15 @@ publish: ## Publish the Docker container to docker hub
 version:
 	npm version
 
-depends: version package.json package-lock.json ## Install node dependencies
-	if [ ! -d node_modules ]; then npm install; fi;
+npmupdate:
+	current=$(pwd)
+	mkdir /tmp/npm
+	cd /tmp/npm
+	npm install --global npm@5.7.0
+	cd $(current)
+
+depends: npmupdate version package.json package-lock.json ## Install node dependencies
+	if [ ! -d node_modules ]; then npm ci; fi;
 
 build: depends ## Compile TypeScript
 	$(TSC)


### PR DESCRIPTION
Fixes #50