### PR TITLE
chore: publish Docker image only on tags

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,12 @@ pipeline {
         }
 
         stage('Publish container') {
-            when { expression { infra.isInfra() } }
+            when {
+                allOf {
+                    expression { infra.isInfra() }
+                    buildingTag()
+                }
+            }
             steps {
                 buildDockerAndPublishImage('uplink', [unstash: 'build'])
             }


### PR DESCRIPTION
This PR avoid publishing a new `latest` Docker image tag on every merge to the primary branch.