### PR TITLE
chore: add dockerhub badge to README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,7 @@
 = Uplink
 
 image:https://ci.jenkins.io/job/Infra/job/uplink/job/master/badge/icon?style=plastic[link="https://ci.jenkins.io/blue/organizations/jenkins/Infra%2Fuplink/branches"]
+image:https://img.shields.io/docker/pulls/jenkinsciinfra/uplink.svg[link="https://hub.docker.com/r/jenkinsciinfra/uplink/"]
 
 `uplink` is a simple web application to receive short bursts of anonymous
 telemetry data from Jenkins instances.


### PR DESCRIPTION
This PR adds a dockerhub badge to the README, providing an useful link to uplink image on Docker Hub.