### PR TITLE
feat!: bump NodeJS from 9 to 20 (LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:20 as builder
 
-RUN npm install --global npm@5.7.0 && \
-    npm version
+RUN npm version
 
 ARG APP_DIR=/srv/uplink
 WORKDIR ${APP_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9 as builder
+FROM node:20 as builder
 
 RUN npm install --global npm@5.7.0 && \
     npm version
@@ -11,7 +11,7 @@ COPY package*json ${APP_DIR}/
 RUN npm ci
 
 # Doing a multi-stage build to reset some stuff for a smaller image
-FROM node:9-alpine
+FROM node:20-alpine
 
 ARG APP_DIR=/srv/uplink
 WORKDIR ${APP_DIR}

--- a/tools/node
+++ b/tools/node
@@ -27,5 +27,5 @@ exec docker run --rm ${TTY_ARGS} --net host  \
     -e DB_CONNECTION_STRING="${DB_CONNECTION_STRING}" \
     -e LOG_LEVEL=$LOG_LEVEL \
     $(printenv | grep -i \^node | awk '{ print "-e", $1 }') \
-    node:10 \
+    node:20 \
     ${COMMAND}


### PR DESCRIPTION
Fixes #48 by specifying the same node version everywhere.

Switching to last LTS version nodejs 20 instead of just updating the Dockerfile as the app run correctly in local.

Supersedes #49 
