### PR TITLE
chore: build docker image on ci.jenkins.io too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,17 +26,9 @@ pipeline {
             }
         }
 
-        stage('Containers') {
-            when { expression { !infra.isInfra() } }
+        stage('Container') {
             steps {
-                sh 'make container'
-            }
-        }
-
-        stage('Publish container') {
-            when { expression { infra.isInfra() } }
-            steps {
-                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64'])
+                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
             }
         }
     }


### PR DESCRIPTION
This PR allows to build the docker image without publication on ci.jenkins.io too, and simplifies a bit the pipeline thanks to https://github.com/jenkins-infra/pipeline-library/pull/784