### PR TITLE
chore(Jenkinsfile): explicitly disable `automaticSemanticVersioning`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 
         stage('Container') {
             steps {
-                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
+                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra(), automaticSemanticVersioning: false])
             }
         }
     }


### PR DESCRIPTION
Related to - https://github.com/jenkins-infra/helpdesk/issues/4165

https://github.com/jenkins-infra/pipeline-library/pull/929 sets `automaticSemanticVersioning` true by default.

Since we want to avoid  automatic versioning, this PR explicitly disables automatic semantic versioning while building the docker image.

This will be a non-regression test for the pipeline.