### PR TITLE
feat!: bump NodeJS to 22 with an Alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20 as builder
+FROM node:22-alpine AS builder
 
 RUN npm version
 
@@ -10,7 +10,7 @@ COPY package*json ${APP_DIR}/
 RUN npm ci
 
 # Doing a multi-stage build to reset some stuff for a smaller image
-FROM node:20-alpine
+FROM node:22-alpine
 
 ARG APP_DIR=/srv/uplink
 WORKDIR ${APP_DIR}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 'POSTGRES_DB=uplink_development'
 
   node:
-    image: node:10
+    image: node:22-alpine
     command: '/usr/local/bin/node $PWD/node_modules/.bin/nodemon build'
     working_dir: $PWD
     environment:

--- a/tools/node
+++ b/tools/node
@@ -27,5 +27,5 @@ exec docker run --rm ${TTY_ARGS} --net host  \
     -e DB_CONNECTION_STRING="${DB_CONNECTION_STRING}" \
     -e LOG_LEVEL=$LOG_LEVEL \
     $(printenv | grep -i \^node | awk '{ print "-e", $1 }') \
-    node:20 \
+    node:22-alpine \
     ${COMMAND}


### PR DESCRIPTION
Following up on #58 , let's use the current NodeJS LTS version.

Looks like a requirement for #61 