### PR TITLE
chore(Jenkinsfile) enable Docker image CD on infra.ci (automatic semantic release)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 
         stage('Container') {
             steps {
-                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra(), automaticSemanticVersioning: false])
+                buildDockerAndPublishImage('uplink', [unstash: 'build', targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
             }
         }
     }


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/4667, it appears we have to update this image.

We've released https://github.com/jenkins-infra/uplink/releases/tag/1.0.0 (first release in a few years) and i did manually set up the Docker Job in infra.ci to discover and build tags newer than 3 days old to ensure this 1.0.0 is released.

It's now time to move forward and enable the CD so we get new releases automatically