### PR TITLE
fix(dockerfile) use an entrypoint script as default CMD to ensure application is always executed after db-migrate task

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22 as builder
+FROM node:22 AS builder
 
 RUN npm version
 
@@ -23,8 +23,8 @@ COPY config ${APP_DIR}/config
 COPY public ${APP_DIR}/public
 COPY views ${APP_DIR}/views
 COPY .sequelizerc ${APP_DIR}/
+COPY ./entrypoint.sh /
 
 EXPOSE 3030
 
-# hadolint ignore=DL3025
-CMD node ./node_modules/.bin/sequelize db:migrate || node ./build/
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -eux
+
+node ./node_modules/.bin/sequelize db:migrate
+
+node ./build/


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/4667#issuecomment-2904244752

Notes:

- We stick to an `sh` script as we are on Alpine
- The `exec` keyword ensure that the `node` process will take over as PID 1 and receive signals